### PR TITLE
Resolve issue with svg-fill mixin

### DIFF
--- a/src/scss/utils/_mixins.scss
+++ b/src/scss/utils/_mixins.scss
@@ -80,7 +80,7 @@
 @mixin svg-fill($color) {
     svg {
         path {
-            fill: $secondary;
+            fill: $color;
         }
     }
 }


### PR DESCRIPTION
It was previously set by default to fill the path with the $secondary colour - I propose changing it to take in the colour being passed in by the mixin function