### PR TITLE
Easier implementation of background images and fonts

### DIFF
--- a/src/scss/utils/_functions.scss
+++ b/src/scss/utils/_functions.scss
@@ -1,4 +1,5 @@
 $rem-base: 16px !default;
+$asset-base-path: "./dist" !default;
 
 @function strip-unit($num) {
     @return $num / ($num * 0 + 1);
@@ -22,4 +23,43 @@ $rem-base: 16px !default;
     }
 
     @return $remValues;
+}
+
+// Assist with declaring fonts and images in CSS
+/* Usage: 
+    @font-face {
+        font-family: 'Unicorn Font';
+        src: font('unicorn.eot?') format('eot'),
+            font('unicorn.otf') format('truetype'),
+            font('unicorn.woff') format('woff'),
+            font('unicorn.svg#unicorn') format('svg');
+        font-weight: normal;
+        font-style: normal;
+    }
+    .foo {
+         background-image: image('kittens.png');
+    }   
+    
+    RENDERS.....
+    @font-face {
+        font-family: 'Unicorn Font';
+        src: url("../assets/fonts/unicorn.eot?") format("eot"), url("../assets/fonts/unicorn.otf") format("truetype"), url("../assets/fonts/unicorn.woff") format("woff"), url("../assets/fonts/unicorn.svg#unicorn") format("svg");
+        font-weight: normal;
+        font-style: normal;
+    }
+
+    .foo {
+        background-image: url("../assets/images/kittens.png");
+    }
+*/
+@function asset($type, $file){
+    @return url($asset-base-path+'/'+$type+'/'+$file);
+}
+
+@function image($file){
+    @return asset('images', $file);
+}
+
+@function font($file){
+    @return asset('fonts', $file);
 }


### PR DESCRIPTION
Using a built-in function to declare the file paths of images and fonts should help cut down on the amount of text in the code